### PR TITLE
[18] Add License

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2022 bitcrowd
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/package.json
+++ b/package.json
@@ -3,7 +3,12 @@
   "version": "2.0.0",
   "description": "Convert from Atlassian Document Format to Markdown Abstract Syntax Tree",
   "license": "MIT",
-  "author": "",
+  "author": {
+    "name": "bitcrowd GmbH.",
+    "url": "https://bitcrowd.net",
+    "email": "info@bitcrowd.net"
+  },
+  "repository": "github:bitcrowd/mdast-util-from-adf",
   "type": "module",
   "main": "./dist/index.js",
   "exports": "./dist/index.js",


### PR DESCRIPTION
Add LICENSE file

We decided to use the MIT license.

Note: it's fine to use 2022 as the year. That's the year when we added the license and it's valid from there on (does not need to be renewed each year).

Small drive-by 🚜: Update package.json info

Add author and repository information to the package.json file. This helps people to find the package on npm.

Closes [#18](https://github.com/bitcrowd/mdast-util-from-adf/issues/18)
