### PR TITLE
[#25] Add support for expand nodes

### DIFF
--- a/index.test.ts
+++ b/index.test.ts
@@ -598,3 +598,30 @@ it("converts layout containers", () => {
     )
   ).toEqual(u("root", [u("paragraph", [u("text", content)])]));
 });
+
+(
+  [
+    ["expand", "expand"],
+    ["nested expand", "nestedExpand"],
+  ] as const
+).forEach(([description, type]) => {
+  it(`converts ${description}`, () => {
+    const text = random.string();
+
+    expect(
+      convert(
+        doc([
+          {
+            type,
+            content: [
+              {
+                type: "paragraph",
+                content: [{ type: "text", text }],
+              },
+            ],
+          },
+        ])
+      )
+    ).toEqual(u("root", [u("paragraph", [u("text", text)])]));
+  });
+});

--- a/index.ts
+++ b/index.ts
@@ -10,6 +10,7 @@ import type {
   DocNode as ADFDoc,
   EmbedCardDefinition as ADFEmbedCard,
   EmojiDefinition as ADFEmoji,
+  ExpandDefinition as ADFExpand,
   HardBreakDefinition as ADFHardBreak,
   HeadingBaseDefinition as ADFHeading,
   Inline as ADFInlineContent,
@@ -57,6 +58,7 @@ type ADFNode =
   | ADFDecisionList
   | ADFEmbedCard
   | ADFEmoji
+  | ADFExpand
   | ADFHardBreak
   | ADFHeading
   | ADFInlineCard
@@ -177,7 +179,7 @@ const handlers: Record<ADFType, Proc<any> | undefined> = {
     const { shortName, text } = adf.attrs;
     return u("text", text ?? shortName);
   }),
-  expand: undefined,
+  expand: skip,
   extension: undefined,
   hardBreak: put(() => u("break")),
   heading: map((adf: ADFHeading) => {
@@ -206,7 +208,7 @@ const handlers: Record<ADFType, Proc<any> | undefined> = {
   mediaInline: undefined,
   mediaSingle: skip,
   mention: put((adf: ADFMention) => u("text", `@${adf.attrs.text}`)),
-  nestedExpand: undefined,
+  nestedExpand: skip,
   orderedList: map(() => u("list", { ordered: true, spread: false }, [])),
   panel: skip,
   paragraph: map(() => u("paragraph", [])),


### PR DESCRIPTION
For now, ADF `expand` and `nestedExpand` nodes will be skipped, meaning
the nodes themselves do not create a counterpart in the resulting MDAST
tree. Their child nodes however will be processed and attached to the
output tree.

An alternative to skipping "expand" nodes could be to represent them as
a sequence of MDAST nodes:

1. HTML node: `<details>`
2. HTML node: `<summary>` + expand node title + `</summary>`
3. MDAST nodes for the "expand" node content (the current output)
4. HTML node: `</details>`

This produces adequate output when converting the ADF to Markdown and
HTML. However, it also comes with its own set of challenges and arguably
makes the MDAST tree representation look rather odd, with HTML nodes
containing invalid HTML content. The opening and closing `<details>`
tags are not valid on their own – though the MDAST documentation
explicitly states that HTML nodes do not need to contain "valid or
complete HTML" (https://github.com/syntax-tree/mdast#html).

For the moment, we go with the "simple" path of ignoring expand nodes.

Closes #25
